### PR TITLE
[bug] Removing redundant : characters from stash_pull_request

### DIFF
--- a/jenkins_jobs/modules/triggers.py
+++ b/jenkins_jobs/modules/triggers.py
@@ -817,9 +817,9 @@ def stash_pull_request(parser, xml_parent, data):
         raise jenkins_jobs.errors.JenkinsJobsException('stash-pull-request is missing "repository-name"')
     XML.SubElement(sprb, 'repositoryName').text = data.get('repository-name', '')
 
-    XML.SubElement(sprb, 'ciSkipPhrases').text = data.get('ci-skip-phrases:', 'NO TEST')
+    XML.SubElement(sprb, 'ciSkipPhrases').text = data.get('ci-skip-phrases', 'NO TEST')
     XML.SubElement(sprb, 'ciBuildPhrases').text = data.get('ci-build-phrases', 'test this please')
-    XML.SubElement(sprb, 'targetBranchesToBuild').text = data.get('target-branches-to-build:', '')
+    XML.SubElement(sprb, 'targetBranchesToBuild').text = data.get('target-branches-to-build', '')
     XML.SubElement(sprb, 'ignoreSsl').text = str(data.get('ignore-ssl', False)).lower()
     XML.SubElement(sprb, 'checkDestinationCommit').text = str(data.get('check-destination-commit', False)).lower()
     XML.SubElement(sprb, 'checkMergeable').text = str(data.get('check-mergeable', False)).lower()


### PR DESCRIPTION
Currently two properties in stash_pull_request are not mapped in xml: ci-skip-phrases and target-branches-to-build. This is caused by redundant colon in property name.